### PR TITLE
Fix compilation using OpenCV 2.4.9.1 (Ubuntu 16.04)

### DIFF
--- a/src/util/draw.cpp
+++ b/src/util/draw.cpp
@@ -40,7 +40,8 @@ namespace dest {
             cv::applyColorMap(values, colors, colormap);
             
             for (core::Shape::Index i = 0; i < s.cols(); ++i) {
-                cv::Scalar color = colors.at<cv::Vec3b>(0, static_cast<int>(i));
+                cv::Vec3b temp = colors.at<cv::Vec3b>(0, static_cast<int>(i));
+                cv::Scalar color(temp[0], temp[1], temp[2]);
                 cv::circle(img, cv::Point2f(s(0, i), s(1 ,i)), 1.f, color, -1, CV_AA);
             }
         }


### PR DESCRIPTION
When compiling in my Ubuntu 16.04 with OpenCV 2.4.9.1, I had to do the following change do avoid compilation errors. It seems the **cv::Scalar** constructor of my OpenCV does not have a version accepting a **cv::Vec3b** object.